### PR TITLE
Toggle language switcher instead of keep opened

### DIFF
--- a/nuxt_src/components/parts/LangSwitcher.vue
+++ b/nuxt_src/components/parts/LangSwitcher.vue
@@ -9,7 +9,7 @@
       <div
         class="selectArea_label"
         :class="{ active: active }"
-        @click="active = true"
+        @click="onClickSelectedLocaleLink"
       >
         {{ selectedLocaleName }}
       </div>
@@ -48,6 +48,10 @@ export default {
     onClickedLocaleLink(url) {
       this.active = false
       location.href = url
+    },
+
+    onClickSelectedLocaleLink() {
+      this.active = !this.active
     }
   }
 }


### PR DESCRIPTION
I am not sure if this is how it should work but, I think that it should close the language switcher dropdown when you click it again.