### PR TITLE
Remove 2020. subdomain from baseUrl and site name

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -49,7 +49,7 @@ module.exports = {
       id: 'UA-51559416-6'
     }],
     ['nuxt-i18n', {
-      baseUrl: 'http://2020.scalamatsuri.org',
+      baseUrl: 'http://scalamatsuri.org',
       locales: [
         {
           code: 'ja',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "2020.scalamatsuri.org",
+  "name": "scalamatsuri.org",
   "version": "0.2.0",
   "description": "The largest international Scala conference in Asia",
   "author": "scalamatsuri.org",


### PR DESCRIPTION
404 page title shows 2020.scalamatsuri.org, while it should do "scalamatsuri.org".

<img width="236" alt="スクリーンショット 2019-12-16 13 48 40" src="https://user-images.githubusercontent.com/1506707/70880620-f6c4a400-200c-11ea-92fb-fbb4549881ec.png">

I also happen to find nuxt-i18n baseUrl is defined as `2020.scalamatsuri.org` .
I also fixed it at once but let me know if it's intended.