### PR TITLE
#68,#70: uncommnet sponsor links

### DIFF
--- a/nuxt_src/components/parts/TheHeader.vue
+++ b/nuxt_src/components/parts/TheHeader.vue
@@ -47,11 +47,11 @@
                 <span>{{ $t('code-of-conduct') }}</span>
               </nuxt-link>
             </li>
-            <!--            <li class="gnav_item" :class="{ 'gnav_item-current': current_path('/sponsor') }">-->
-            <!--              <nuxt-link :to="localePath('sponsor')">-->
-            <!--                <span>{{ $t('sponsor') }}</span>-->
-            <!--              </nuxt-link>-->
-            <!--            </li>-->
+            <li class="gnav_item" :class="{ 'gnav_item-current': current_path('/sponsor') }">
+              <nuxt-link :to="localePath('sponsor')">
+                <span>{{ $t('sponsor') }}</span>
+              </nuxt-link>
+            </li>
             <li class="gnav_item" :class="{ 'gnav_item-current': current_path('/#access') }">
               <nuxt-link :to="locale_access_link()">
                 <span>{{ $t('access') }}</span>
@@ -132,11 +132,11 @@
                   <span>{{ $t('code-of-conduct') }}</span>
                 </nuxt-link>
               </li>
-              <!--              <li class="gnav_item" :class="{ 'gnav_item-current': current_path('/sponsor') }" @click="toggleMenu()">-->
-              <!--                <nuxt-link :to="localePath('sponsor')">-->
-              <!--                  <span>{{ $t('sponsor') }}</span>-->
-              <!--                </nuxt-link>-->
-              <!--              </li>-->
+              <li class="gnav_item" :class="{ 'gnav_item-current': current_path('/sponsor') }" @click="toggleMenu()">
+                <nuxt-link :to="localePath('sponsor')">
+                  <span>{{ $t('sponsor') }}</span>
+                </nuxt-link>
+              </li>
               <li class="gnav_item" :class="{ 'gnav_item-current': current_path('#access') }" @click="toggleMenu()">
                 <nuxt-link :to="locale_access_link()">
                   <span>{{ $t('access') }}</span>

--- a/nuxt_src/components/sections/top/banner.vue
+++ b/nuxt_src/components/sections/top/banner.vue
@@ -10,9 +10,9 @@ ja:
 <template>
   <div class="banner">
     <div class="banner_list">
-      <!-- <nuxt-link :to="localePath('sponsorship')" class="banner_item banner_item-sponsor"> -->
-      <!--   <span>{{ $t('sponsorship') }} </span> -->
-      <!-- </nuxt-link> -->
+      <nuxt-link :to="localePath('sponsorship')" class="banner_item banner_item-sponsor">
+        <span>{{ $t('sponsorship') }} </span>
+      </nuxt-link>
       <nuxt-link :to="localePath('cfp')" class="banner_item banner_item-staff">
         <span>{{ $t('cfp') }}</span>
       </nuxt-link>


### PR DESCRIPTION
Resolves: #68, #70 

![ScalaMatsuri_2020___アジア最大級の_Scala_のカンファレンス](https://user-images.githubusercontent.com/16359063/70917825-63698e00-2061-11ea-9c4d-5ba52d9c4569.png)

- uncomment sponsor links on header
- uncomment sponsor link button at top page
