### PR TITLE
make sponsor logo background white

### DIFF
--- a/nuxt_src/assets/scss/top/_sp.scss
+++ b/nuxt_src/assets/scss/top/_sp.scss
@@ -54,6 +54,10 @@
 }
 .sponsors_list {
   padding: 0;
+
+  img {
+    background: white;
+  }
 }
 .sponsors_item {
   width: 50%;
@@ -63,6 +67,10 @@
 
 .sponsors_list-bugyo .sponsors_item {
   width: 50%;
+
+  img {
+    background: white;
+  }
 }
 .banner {
   margin-top: 20px;

--- a/nuxt_src/assets/scss/top/_top.scss
+++ b/nuxt_src/assets/scss/top/_top.scss
@@ -380,6 +380,7 @@
 
   img {
     width: 100%;
+    background: white;
   }
 }
 .sponsors_list-bugyo {
@@ -391,6 +392,7 @@
 
     img {
       max-width: 100%;
+      background: white;
     }
   }
 }
@@ -488,6 +490,7 @@
     margin-bottom: 24px;
     img {
       max-width: 100%;
+      background: white;
     }
   }
 }


### PR DESCRIPTION
スポンサーロゴ画像が透過の場合、ロゴ規定上問題が発生したり、見辛くなるため、白背景を追加する。