### PR TITLE
fix bugyo layout to put three logos per row

### DIFF
--- a/nuxt_src/assets/scss/top/_sp.scss
+++ b/nuxt_src/assets/scss/top/_sp.scss
@@ -54,24 +54,11 @@
 }
 .sponsors_list {
   padding: 0;
-
-  img {
-    background: white;
-  }
 }
 .sponsors_item {
   width: 50%;
-  padding: 0 10px;
-  margin-top: 20px;
 }
 
-.sponsors_list-bugyo .sponsors_item {
-  width: 50%;
-
-  img {
-    background: white;
-  }
-}
 .banner {
   margin-top: 20px;
 }

--- a/nuxt_src/assets/scss/top/_top.scss
+++ b/nuxt_src/assets/scss/top/_top.scss
@@ -339,7 +339,6 @@
   margin-top: 67px;
   font-size: 20px;
   font-weight: bold;
-  font-weight: bold;
   line-height: normal;
   color: #4F4C47;
   background: -webkit-linear-gradient(0deg, #7F797F, #4F4C47);
@@ -368,7 +367,6 @@
   padding: 0 10px;
 }
 
-
 .sponsors_inner {
 
 }
@@ -382,20 +380,13 @@
     width: 100%;
     background: white;
   }
-}
-.sponsors_list-bugyo {
-  max-width: 1028px;
-  .sponsors_item {
-    padding: 0 10px;
-    width: 25%;
-    margin-top: 20px;
-
-    img {
-      max-width: 100%;
-      background: white;
-    }
+  p {
+    padding-top: 6px;
+    font-size: 16px;
+    color: #4F4C47;
   }
 }
+
 @media screen and (max-width: $viewport - 1) {
   @import "sp";
 }

--- a/nuxt_src/components/sections/top/sponsors.vue
+++ b/nuxt_src/components/sections/top/sponsors.vue
@@ -76,7 +76,7 @@ ja:
       <h3 class="sponsors_subtitle">
         {{ $t('bugyo') }}
       </h3>
-      <ul class="sponsors_list sponsors_list-bugyo">
+      <ul class="sponsors_list">
         <li v-for="sponsor in bugyos" :key="sponsor.logo" class="sponsors_item">
           <a :href="sponsor.url"><img v-lazy="sponsor.logo" :alt="sponsor.name"></a>
           <p> {{ sponsor.display_name }} </p>


### PR DESCRIPTION
奉行ロゴだけ4つ並んでしまう問題を修正。
ついでに文字にスタイルが設定されてなかったので、軽く修正しました。

![スクリーンショット 2020-02-06 14 56 49](https://user-images.githubusercontent.com/1506707/73912368-ac1e2480-48f7-11ea-9942-7f3720df1391.png)

