### PR TITLE
TOPページの登壇者アイコンをlazyload対応

### DIFF
--- a/nuxt_src/components/sections/candidates/tableRow.vue
+++ b/nuxt_src/components/sections/candidates/tableRow.vue
@@ -27,7 +27,7 @@
     <!-- 登壇者 ここから -->
     <div v-for="speaker in program[locale].speakers" :key="speaker.name" class="schedule_speakers">
       <div class="schedule_speaker">
-        <div class="schedule_speaker_icon" :style="`background-image: url('${speaker.icon}')`" />
+        <img v-lazy="speaker.icon" class="schedule_speaker_icon">
         <p class="schedule_speaker_name">
           {{ speaker.name }}
         </p>


### PR DESCRIPTION
単純に前回の対応時の漏れで、初回読み込み時に多くの時間を要するようにしてしまっていたので、修正させてください。

| Before | After |
|-----|-----|
| ![Kapture 2020-08-06 at 21 15 38](https://user-images.githubusercontent.com/16359063/89530934-5553c200-d82a-11ea-8fd5-ec1d41f3ebff.gif) | ![Kapture 2020-08-06 at 21 14 45](https://user-images.githubusercontent.com/16359063/89530871-36553000-d82a-11ea-9eef-d6298ee36c98.gif) |