### PR TITLE
プレScalaMatsuriのTOP掲載

### DIFF
--- a/nuxt_src/components/sections/top/preEvent.vue
+++ b/nuxt_src/components/sections/top/preEvent.vue
@@ -1,0 +1,29 @@
+<i18n>
+## language=yaml
+ja:
+  event_overview: |
+    この度8月30日(日)に プレScalaMatsuri 兼 リハーサルとして、オンラインLT大会を開催します。<br>
+    開催概要を以下イベントページからご確認の上、奮ってご参加ください。
+  event_link: イベントページはこちら
+en:
+  event_overview: |
+    On Sunday, August 30th, we will be holding a pre-ScalaMatsuri and online LT competition as a rehearsal for the upcoming ScalaMatsuri.<br>
+    Please check out the event page below and join us.
+  event_link: Click here for event page
+</i18n>
+
+<template>
+  <section class="content pre-events">
+    <div class="content_inner">
+      <h2 class="content_title">
+        Pre-ScalaMatsuri
+      </h2>
+      <p class="content_text">
+        <span v-html="$t('event_overview')" />
+      </p>
+      <p class="content_link">
+        <a href="">{{ $t('event_link') }}</a><img v-lazy="require('~/assets/img/common/arrow-next-b.svg')" alt="">
+      </p>
+    </div>
+  </section>
+</template>

--- a/nuxt_src/components/sections/top/preEvent.vue
+++ b/nuxt_src/components/sections/top/preEvent.vue
@@ -2,12 +2,12 @@
 ## language=yaml
 ja:
   event_overview: |
-    この度8月30日(日)に プレScalaMatsuri 兼 リハーサルとして、オンラインLT大会を開催します。<br>
+    8月30日(日) 17:00 より、プレScalaMatsuri 兼 リハーサルとして、オンラインLT大会を開催します。<br>
     開催概要を以下イベントページからご確認の上、奮ってご参加ください。
   event_link: イベントページはこちら
 en:
   event_overview: |
-    On Sunday, August 30th, we will be holding a pre-ScalaMatsuri and online LT competition as a rehearsal for the upcoming ScalaMatsuri.<br>
+    On Sunday, August 30th, we will be holding a pre-ScalaMatsuri Lightning Talks online meetup, which is also intended as a rehearsal for the upcoming ScalaMatsuri.<br>
     Please check out the event page below and join us.
   event_link: Click here for event page
 </i18n>

--- a/nuxt_src/components/sections/top/preEvent.vue
+++ b/nuxt_src/components/sections/top/preEvent.vue
@@ -22,7 +22,7 @@ en:
         <span v-html="$t('event_overview')" />
       </p>
       <p class="content_link">
-        <a href="">{{ $t('event_link') }}</a><img v-lazy="require('~/assets/img/common/arrow-next-b.svg')" alt="">
+        <a href="https://scalaconfjp.doorkeeper.jp/events/110045" target="_blank" rel="noopener">{{ $t('event_link') }}</a><img v-lazy="require('~/assets/img/common/arrow-next-b.svg')">
       </p>
     </div>
   </section>

--- a/nuxt_src/pages/index.vue
+++ b/nuxt_src/pages/index.vue
@@ -3,6 +3,7 @@
     <main-visual />
     <news :posts="blogPosts" />
     <banner />
+    <pre-event />
     <events />
     <accepted-sessions />
     <access />
@@ -24,10 +25,13 @@ import info from '@/components/sections/top/info'
 import topSponsors from '@/components/sections/top/sponsors'
 import AcceptedSessions from '@/components/sections/top/AcceptedSessions'
 
+import preEvent from '@/components/sections/top/preEvent'
+
 export default {
   components: {
     mainVisual,
     news,
+    preEvent,
     banner,
     events,
     access,


### PR DESCRIPTION
### TODO
- [x] 実際のイベントページのリンク適用

### 概要
プレイベントページへの動線をTOPページに追加しました。
文言や、他にこんなコンテンツを乗せるてもよいのでは、みたいな点を皆様からレビューいただきたいです。

| JP | ENG |
|-----|-----|
| <img width="368" alt="ScalaMatsuri_2020___アジア最大級の_Scala_のカンファレンス" src="https://user-images.githubusercontent.com/16359063/89621241-f5adf300-d8cb-11ea-95b8-dc4931c981f1.png"> | <img width="367" alt="ScalaMatsuri_2020___The_largest_international_Scala_conference_in_Asia" src="https://user-images.githubusercontent.com/16359063/89621207-e75fd700-d8cb-11ea-9689-bc00a22a859f.png"> |
| <img width="995" alt="ScalaMatsuri_2020___アジア最大級の_Scala_のカンファレンス" src="https://user-images.githubusercontent.com/16359063/89620932-6c96bc00-d8cb-11ea-9851-5eceaa4ad923.png"> | <img width="1357" alt="ScalaMatsuri_2020___The_largest_international_Scala_conference_in_Asia" src="https://user-images.githubusercontent.com/16359063/89621175-d9aa5180-d8cb-11ea-83aa-efafd057ae81.png"> |