### PR TITLE
#410 子守奉行ロゴを取り下げる

### DIFF
--- a/nuxt_src/components/sections/top/sponsors.vue
+++ b/nuxt_src/components/sections/top/sponsors.vue
@@ -13,7 +13,6 @@ en:
   bugyo_cacoo: "Ukiyo-e Bugyo"
   bugyo_hatena: "Kawara-ban Bugyo"
   bugyo_sentry: "Metsuke Bugyo"
-  bugyo_nextbeat: "Lullaby Bugyo"
 ja:
   sponsor_overview: |
     アジア最大級の国際Scalaカンファレンスである、ScalaMatsuriに協賛いただけるスポンサー様を募集しています。<br>
@@ -27,7 +26,6 @@ ja:
   bugyo_cacoo: "浮世絵奉行"
   bugyo_hatena: "瓦版奉行"
   bugyo_sentry: "目付奉行"
-  bugyo_nextbeat: "子守奉行"
 </i18n>
 <template>
   <section class="sponsors">
@@ -125,12 +123,6 @@ export default {
           'logo': '/img/sponsors/sentry.svg',
           'url': 'https://sentry.io/',
           'display_name': this.$i18n.t('bugyo_sentry')
-        },
-        {
-          'name': 'nextbeat',
-          'logo': '/img/sponsors/kidsnasitter.png',
-          'url': 'https://sitter.kidsna.com/',
-          'display_name': this.$i18n.t('bugyo_nextbeat')
         }
       ]
     }


### PR DESCRIPTION
closes: #410 

<img width="1781" alt="ScalaMatsuri_2020___The_largest_international_Scala_conference_in_Asia_と_ScalaMatsuri_2020___The_largest_international_Scala_conference_in_Asia_と_子守奉行ロゴを取り下げる_·_Issue__410_·_scalamatsuri_2020_scalamatsuri_org_と_Slack___app_web___ScalaMatsur" src="https://user-images.githubusercontent.com/16359063/89851559-b6331f80-dbc7-11ea-80f6-e150474e9cf7.png">
