### PR TITLE
clarify 16:9 is fine

### DIFF
--- a/nuxt_src/pages/slides/index.vue
+++ b/nuxt_src/pages/slides/index.vue
@@ -19,7 +19,7 @@ en:
   body_03: |
     Please submit your slide decks by Sep 11th 23:59 AoE to cfp@scalamatsuri.org .
     <br/>
-    ScalaMatsuri staff will provide the translation, and also check for Code of Conduct compliance. Since the translation will be done based on text, if you could please submit a text file with all the texts along with your slide deck, it would be most appreciated (like a lot)! The slide deck will also be submitted to the interpreters. If you send it as PowerPoint, Google slide show, or Keynote format, we put/fix “subtitles” directly. Otherwise, we send you a translated/fixed text file, so you put/fix by yourself. We recommend 4:3 aspect ratio, but also 16:9 OK.
+    ScalaMatsuri staff will provide the translation, and also check for Code of Conduct compliance. Since the translation will be done based on text, if you could please submit a text file with all the texts along with your slide deck, it would be most appreciated (like a lot)! The slide deck will also be submitted to the interpreters. If you send it as PowerPoint, Google slide show, or Keynote format, we put/fix “subtitles” directly. Otherwise, we send you a translated/fixed text file, so you put/fix by yourself. It's fine to choose 4:3 or 16:9 aspect ratio.
     <br/>
     If you have any changes by then, feel free to submit the new deck along with the change description such as “changed the text on page 3.” Any changes after February 10th will be at your own risk.
   title_04: Your slides of the day
@@ -44,7 +44,7 @@ ja:
   body_03: |
     発表資料は9/11(土)23:59 AoE（9/12 20:59 JST）まで cfp[at]scalamatsuri.org へ提出して下さい。
     <br/>
-    スタッフ側で発表資料の本文・字幕の翻訳の確認、および行動規範への準拠の確認を行います。 翻訳作業はチーム内ではテキストベースで行うので、スライドと共にテキスト部だけを書きだしたテキストファイルをご提出下さい。 また、資料の形式を、PowerPoint,Google スライドショー、Keynoteのいずれかで提出いただけた場合は、翻訳、チェック後の字幕をこちらで挿入/修正いたします。それ以外の場合は、翻訳/修正したテキストファイルをお送りしますので、ご自身で字幕の挿入/修正をお願いいたします。 画面の比率は4:3が望ましいですが、16:9でも大丈夫です。
+    スタッフ側で発表資料の本文・字幕の翻訳の確認、および行動規範への準拠の確認を行います。 翻訳作業はチーム内ではテキストベースで行うので、スライドと共にテキスト部だけを書きだしたテキストファイルをご提出下さい。 また、資料の形式を、PowerPoint,Google スライドショー、Keynoteのいずれかで提出いただけた場合は、翻訳、チェック後の字幕をこちらで挿入/修正いたします。それ以外の場合は、翻訳/修正したテキストファイルをお送りしますので、ご自身で字幕の挿入/修正をお願いいたします。 画面の比率は4:3、16:9どちらでも構いません。
     <br/>
     ScalaMatsuri 開催2週間前ぐらいに発表資料をお返しすると共に、同時通訳者へ資料の提出を行います。 また、それまでは発表資料の差し替えを随時受け付けます。差し替えの際には、新しい資料に変更内容の概要（「3ページ目の文章を修正」など）を添えて提出してください。直前に資料を修正して頂いても構いませんが、その場合は内容についてのレビューはできませんので自己責任でお願いします。
   title_04: 当日の発表資料


### PR DESCRIPTION
スライドのアスペクト比が16:9でも問題ないことを明記しました。
（オンライン化にともない、プロジェクターを使わなくなったため）