### PR TITLE
#423: 

### DIFF
--- a/nuxt_src/assets/scss/top/_sp.scss
+++ b/nuxt_src/assets/scss/top/_sp.scss
@@ -109,8 +109,6 @@
   line-height: 1.2em;
   a {
     font-size: 14px;
-    padding-left: 10px;
-    padding-right: 10px;
     > img {
       display: none;
     }
@@ -122,6 +120,8 @@
   -webkit-line-clamp: 1;
   overflow: hidden;
   height: 40px;
+  padding-left: 10px;
+  padding-right: 10px;
 }
 .news_item-show {
   top: 10px;

--- a/nuxt_src/assets/scss/top/_top.scss
+++ b/nuxt_src/assets/scss/top/_top.scss
@@ -65,6 +65,8 @@
   position: absolute;
   top: -50px;
   left: 0;
+  padding: 0 38px;
+  max-height: 60px;
 }
 .news_item-show {
   top: 0;
@@ -100,8 +102,6 @@
     color: #FFF;
     font-weight: bold;
     font-size: 18px;
-    padding: 0 38px;
-    display: block;
   }
 
   img {

--- a/nuxt_src/components/sections/top/news.vue
+++ b/nuxt_src/components/sections/top/news.vue
@@ -29,9 +29,11 @@ export default {
       intervalId: null // for setInterval and clearInterval
     }
   },
-  mounted: function () {
-    if (this.posts && this.posts.length > 0) {
-      this.intervalId = setInterval(() => { this.currentIdx = (this.currentIdx + 1) % this.posts.length }, 5000)
+  watch: {
+    posts: function (newPosts, _) {
+      if (newPosts.length > 0) {
+        this.intervalId = setInterval(() => { this.currentIdx = (this.currentIdx + 1) % newPosts.length }, 5000)
+      }
     }
   },
   beforeDestroy: function () {


### PR DESCRIPTION
closes: #423 

## 原因
日本語の5月1日の記事タイトルが長く、しかもaタグをblockタグとしてpaddingを設定していたのもあって、直前のリンクを覆ってしまっていた。

![image](https://user-images.githubusercontent.com/16359063/90507268-99cb5000-e190-11ea-8012-0433691a3c38.png)

上記画像から、オンライン開催のリンクを、直前の採用セッション決定記事へのリンクが完全に覆ってしまっていることが見て取れる。

なので現象としては、リンク先が異なるのではなく、特定リンクのサイズが大きすぎるため他リンクを覆ってしまっていたということになる。