### PR TITLE
直前期スタッフ募集ページの追加

### DIFF
--- a/nuxt_src/assets/img/top/en/img-main_title-pc.svg
+++ b/nuxt_src/assets/img/top/en/img-main_title-pc.svg
@@ -4,7 +4,7 @@
     <title>en-PC</title>
     <desc>Created with Sketch.</desc>
     <g id="en-PC" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" font-family="NotoSansJP-Medium, Noto Sans JP" font-weight="400">
-        <text id="The-largest-Scala-co" font-size="38" letter-spacing="4.068956" fill="#FFFFFF">
+        <text id="The-largest-Scala-co" font-size="36" letter-spacing="4.068956" fill="#FFFFFF">
             <tspan x="4" y="54">The largest Scala conference in Asia</tspan>
         </text>
         <text id="17th-and-18th-Oct.-2" font-size="20" letter-spacing="2.59945" fill="#FFFFFF">

--- a/nuxt_src/components/parts/TheHeader.vue
+++ b/nuxt_src/components/parts/TheHeader.vue
@@ -10,6 +10,7 @@
     login: "Log in"
     ticket: "Ticket"
     cfp: "CFP"
+    extra-staff: "Extra Staffs(ja)"
     logout: "Log Out"
     logout_successful: "Logged out successfully."
   ja:
@@ -22,6 +23,7 @@
     login: "ログイン"
     ticket: "チケット購入"
     cfp: "セッション募集"
+    extra-staff: "スタッフ募集"
     logout: "ログアウト"
     logout_successful: "ログアウトしました."
 </i18n>
@@ -61,6 +63,11 @@
             <li class="gnav_item" :class="{ 'gnav_item-current': current_path('/sponsors') }">
               <nuxt-link :to="localePath('sponsors')">
                 <span>{{ $t('sponsors') }}</span>
+              </nuxt-link>
+            </li>
+            <li class="gnav_item" :class="{ 'gnav_item-current': current_path('/extra-staff') }">
+              <nuxt-link :to="localePath('extra-staff')">
+                <span>{{ $t('extra-staff') }}</span>
               </nuxt-link>
             </li>
             <!-- <li class="gnav_item" :class="{ 'gnav_item-current': current_path('/#access') }">

--- a/nuxt_src/components/sections/top/ecShop.vue
+++ b/nuxt_src/components/sections/top/ecShop.vue
@@ -1,11 +1,13 @@
 <i18n>
 ## language=yaml
 ja:
+  title: ScalaMatsuri Tシャツショップ
   overview: |
     ScalaMatsuriTシャツのオンラインショップが、期間限定でオープンしました！過去最多の7色展開です。
   ecshop_japan_link: 日本からのみ注文可能なショップはこちら
   ecshop_world_link: 全世界から注文可能なショップはこちら
 en:
+  title: ScalaMatsuri T-shirt shop
   overview: |
     ScalaMatsuri T-shirts online shop has been open for a limited period! There are seven color T-shirts. Please choose the one you like.
   ecshop_japan_link: Japan Domestic Orders
@@ -16,7 +18,7 @@ en:
   <section class="content pre-events">
     <div class="content_inner">
       <h2 class="content_title">
-        ScalaMatsuri T-shirt shop
+        {{ $t('title') }}
       </h2>
       <p class="content_text">
         <span v-html="$t('overview')" />

--- a/nuxt_src/components/sections/top/ecShop.vue
+++ b/nuxt_src/components/sections/top/ecShop.vue
@@ -1,0 +1,32 @@
+<i18n>
+## language=yaml
+ja:
+  overview: |
+    ScalaMatsuriTシャツのオンラインショップが、期間限定でオープンしました！過去最多の7色展開です。
+  ecshop_japan_link: 日本からのみ注文可能なショップはこちら
+  ecshop_world_link: 全世界から注文可能なショップはこちら
+en:
+  overview: |
+    ScalaMatsuri T-shirts online shop has been open for a limited period! There are seven color T-shirts. Please choose the one you like.
+  ecshop_japan_link: Japan Domestic Orders
+  ecshop_world_link: Worldwide Orders
+</i18n>
+
+<template>
+  <section class="content pre-events">
+    <div class="content_inner">
+      <h2 class="content_title">
+        ScalaMatsuri T-shirt shop
+      </h2>
+      <p class="content_text">
+        <span v-html="$t('overview')" />
+      </p>
+      <p class="content_link">
+        <a href="https://scalamatsuri.official.ec/" target="_blank" rel="noopener">{{ $t('ecshop_japan_link') }}</a><img v-lazy="require('~/assets/img/common/arrow-next-b.svg')">
+      </p>
+      <p class="content_link">
+        <a href="https://scalamatsuri.myshopify.com/collections/all" target="_blank" rel="noopener">{{ $t('ecshop_world_link') }}</a><img v-lazy="require('~/assets/img/common/arrow-next-b.svg')">
+      </p>
+    </div>
+  </section>
+</template>

--- a/nuxt_src/pages/extra-staff/index.vue
+++ b/nuxt_src/pages/extra-staff/index.vue
@@ -68,7 +68,7 @@
           <dd>
             <ul>
               <li>チケット代無料</li>
-              <li><a href="https://scalamatsuri.official.ec/">Tシャツ</a>割引クーポン(システム下限の50円となります)</li>
+              <li><a href="https://scalamatsuri.official.ec/" target="_blank" rel="noopener">Tシャツ</a>割引クーポン(システム下限の50円となります)</li>
               <li>後日のスタッフ打ち上げへの参加</li>
             </ul>
           </dd>

--- a/nuxt_src/pages/extra-staff/index.vue
+++ b/nuxt_src/pages/extra-staff/index.vue
@@ -3,7 +3,7 @@
     <div class="main">
       <div class="main_inner">
         <h1 class="main_title">
-          当日スタッフ募集
+          直前期スタッフ募集
         </h1>
       </div>
     </div>
@@ -11,80 +11,85 @@
       <img v-lazy="require('~/assets/img/extra-staff/img-main.jpg')" alt="" class="lead_img is_sp">
       <div class="lead_inner">
         <h2 class="lead_text">
-          開催前日準備、当日のお手伝いを<br>してくれる方を募集しています。
+          イベントを一緒に盛り上げる<br>仲間を募集しています
         </h2>
         <div class="section_btnArea lead_btnArea">
-          <a href="https://docs.google.com/forms/d/e/1FAIpQLSeoh2Lgd3LiMxKRjdLtu9Ul1DGZLN54srPdbvIjWoAsFz-rAA/viewform" target="_blank" rel="noopener" class="section_btn section_btn-l">当日スタッフに応募する</a>
+          <a href="https://forms.gle/SkbscteHs4nzGPZB8" target="_blank" rel="noopener" class="section_btn section_btn-l">スタッフに応募する</a>
         </div>
       </div>
     </div>
     <p class="catch">
-      運営にご興味のある方、一緒にScalaMatsuriを盛り上げていきたい方は是非当日スタッフとしてのご参加も検討下さい。
+      カンファレンス運営に興味のある方、Scalaコミュニティを盛り上げていきたい方は、是非当日スタッフとしてのご参加を検討下さい。
     </p>
 
     <div class="section">
       <h2 class="section_title">
-        <span class="section_title_inner">当日スタッフ概要</span>
+        <span class="section_title_inner">直前期スタッフ概要</span>
       </h2>
       <div class="section_table1">
         <dl>
-          <dt>開催日（予定）</dt>
-          <dd><em>2020年5/14(木) 〜 5/16(土)</em><br>前日準備を含めて最大三日間の予定です。また、当日の作業の事前説明会も開催予定です。詳細は決まり次第、追ってご連絡します。</dd>
+          <dt>開催日</dt>
+          <dd><em>2020年10/17(土) 〜 10/18(日)</em><br>当日の作業やZoom Webinarの扱い方について事前説明会も開催します。</dd>
         </dl>
         <dl>
-          <dt>開催時間（予定）</dt>
-          <dd><em>00:00 〜 99:00</em></dd>
+          <dt>開催時間</dt>
+          <dd><em>9:30 〜 19:00</em>(懇親会参加の場合は21:00)</dd>
         </dl>
         <dl>
-          <dt>開催地（予定）</dt>
-          <dd><em>国際交流館</em>（ <a href="https://goo.gl/maps/6CVQ4ZvJMDS2" target="_blank" rel="noopener">Google Maps</a> ）</dd>
+          <dt>開催地</dt>
+          <dd><em>ScalaMatsuri DiscordサーバーおよびZoom Webinar</em></dd>
         </dl>
         <dl>
           <dt>応募方法</dt>
-          <dd><em>応募フォームよりご連絡のつくメールアドレスを入力して下さい。</em><br>後日、こちらでご入力いただいたメールアドレス宛に詳細のご連絡や、Slackのご招待を送ります。招待をお送りするのは開催一ヶ月前ぐらいになる予定です。</dd>
-        </dl>
-        <dl>
-          <dt>お手伝い内容（シフト制）</dt>
           <dd>
+            <em>応募フォームよりご連絡のつくメールアドレスを入力して下さい。</em><br>
+            後日、こちらでご入力いただいたメールアドレス宛に詳細のご連絡や、Slackのご招待を送ります。
+          </dd>
+        </dl>
+
+        <dl>
+          <dt>スタッフ業の内容</dt>
+          <dd>
+            <p>事前（希望者のみ）</p>
             <ul>
-              <li>前日準備、後片付け</li>
-              <li>懇親会準備</li>
-              <li>受付</li>
-              <li>お菓子やコーヒーの補充</li>
-              <li>セッションタイムキーパー</li>
-              <li>お弁当の配布</li>
+              <li>スライドの和訳字幕付け</li>
+              <li>Webサイト改修（Nuxt.js @ Firebase Hosting)</li>
             </ul>
-            <p>シフト時間外は自由にScalaMatsuriを楽しんでください！</p>
+            <p>カンファレンス当日</p>
+            <p>(シフト時間外は自由にScalaMatsuriを楽しんでください！)</p>
+            <ul>
+              <li>各セッションのタイムキーパー、司会</li>
+              <li>アンカンファレンス</li>
+            </ul>
           </dd>
         </dl>
         <dl>
-          <dt>当日スタッフ特典(予定)</dt>
+          <dt>スタッフ特典</dt>
           <dd>
             <ul>
-              <li>チケット代無料+チケットに付く特典類(Tシャツは希望サイズをお渡し出来ない場合があります)</li>
-              <li>スタッフTシャツ(ただし、サイズがない場合はお渡し出来ない場合があります)</li>
+              <li>チケット代無料</li>
+              <li><a href="https://scalamatsuri.official.ec/">Tシャツ</a>割引クーポン(システム下限の50円となります)</li>
               <li>後日のスタッフ打ち上げへの参加</li>
             </ul>
           </dd>
         </dl>
       </div>
       <div class="section_btnArea">
-        <a href="https://docs.google.com/forms/d/e/1FAIpQLSeoh2Lgd3LiMxKRjdLtu9Ul1DGZLN54srPdbvIjWoAsFz-rAA/viewform" target="_blank" rel="noopener" class="section_btn section_btn-l">当日スタッフに応募する</a>
+        <a href="https://forms.gle/SkbscteHs4nzGPZB8" target="_blank" rel="noopener" class="section_btn section_btn-l">スタッフに応募する</a>
       </div>
     </div>
   </div>
 </template>
 
 <script>
-import Page404NotFoundMixin from '@/mixins/page/Page404NotFound.js'
+// import Page404NotFoundMixin from '@/mixins/page/Page404NotFound.js'
 export default {
-  // TODO: スポンサーが決定し次第、404表示を解除する
-  mixins: [Page404NotFoundMixin],
+  // mixins: [Page404NotFoundMixin],
   head() {
     return {
-      title: '当日スタッフ募集',
+      title: '直前期スタッフ募集',
       meta: [
-        { name: 'og:title', content: '当日スタッフ募集 | ScalaMatsuri 2020' }
+        { name: 'og:title', content: '直前期スタッフ募集 | ScalaMatsuri 2020' }
       ]
     }
   }

--- a/nuxt_src/pages/index.vue
+++ b/nuxt_src/pages/index.vue
@@ -3,7 +3,7 @@
     <main-visual />
     <news :posts="blogPosts" />
     <banner />
-    <pre-event />
+    <ec-shop />
     <events />
     <accepted-sessions />
     <!-- <access /> -->
@@ -25,13 +25,13 @@ import info from '@/components/sections/top/info'
 import topSponsors from '@/components/sections/top/sponsors'
 import AcceptedSessions from '@/components/sections/top/AcceptedSessions'
 
-import preEvent from '@/components/sections/top/preEvent'
+import ecShop from '@/components/sections/top/ecShop'
 
 export default {
   components: {
     mainVisual,
     news,
-    preEvent,
+    ecShop,
     banner,
     events,
     // access,


### PR DESCRIPTION
当日スタッフ＋翻訳スタッフ＋Webサイトメンテナ募集、ということで「直前期スタッフ募集」という名称にしてみました。

![6d80be20674cb17886fc6480b58b6c16](https://user-images.githubusercontent.com/1506707/92931130-f6fbae00-f47d-11ea-94da-e548b7851df4.jpg)
![f75b102609d8877287fd7eb310f66667](https://user-images.githubusercontent.com/1506707/92931133-f82cdb00-f47d-11ea-8dfc-743cad65ed93.png)
