### PR TITLE
hide sponsorship and extra-staff page

### DIFF
--- a/nuxt_src/assets/scss/extra-staff/_extra-staff.scss
+++ b/nuxt_src/assets/scss/extra-staff/_extra-staff.scss
@@ -35,6 +35,12 @@ letter-spacing: 0.1em;
   margin-top: 30px;
   padding: 0 20px;
 }
+.extrastaff_note {
+  font-size: 14px;
+  text-align: center;
+  letter-spacing: 0.1em;
+  margin-top: 40px;
+}
 @media screen and (max-width: $viewport - 1) {
   @import "sp";
 }

--- a/nuxt_src/assets/scss/extra-staff/_sp.scss
+++ b/nuxt_src/assets/scss/extra-staff/_sp.scss
@@ -23,3 +23,7 @@
   line-height: 1.5;
   font-size: 4.3vw;
 }
+.extrastaff_note {
+  margin-top: 20px;
+  text-align: left;
+}

--- a/nuxt_src/assets/scss/top/_sp.scss
+++ b/nuxt_src/assets/scss/top/_sp.scss
@@ -83,7 +83,12 @@
   }
 
   &-sponsor {
-    background-color: #4F9AD5;
+    span {
+      zoom: 0.7;
+      margin-bottom: 10px;
+    }
+  }
+  &-tshirt {
     span {
       zoom: 0.7;
       margin-bottom: 10px;

--- a/nuxt_src/assets/scss/top/_top.scss
+++ b/nuxt_src/assets/scss/top/_top.scss
@@ -47,6 +47,12 @@
 
     }
   }
+  &-tshirt {
+    background-color: #cb534e;
+    span {
+      background-image: url('~assets/img/common/icon-mikoshi.svg');
+    }
+  }
   &-staff {
     background-color: #E4AE2F;
   }

--- a/nuxt_src/components/parts/TheHeader.vue
+++ b/nuxt_src/components/parts/TheHeader.vue
@@ -65,11 +65,13 @@
                 <span>{{ $t('sponsors') }}</span>
               </nuxt-link>
             </li>
+            <!--
             <li class="gnav_item" :class="{ 'gnav_item-current': current_path('/extra-staff') }">
               <nuxt-link :to="localePath('extra-staff')">
                 <span>{{ $t('extra-staff') }}</span>
               </nuxt-link>
             </li>
+            -->
             <!-- <li class="gnav_item" :class="{ 'gnav_item-current': current_path('/#access') }">
               <nuxt-link :to="locale_access_link()">
                 <span>{{ $t('access') }}</span>

--- a/nuxt_src/components/sections/top/banner.vue
+++ b/nuxt_src/components/sections/top/banner.vue
@@ -2,22 +2,33 @@
 ## language=yaml
 en:
   sponsorship: "Sponsorship(ja)"
+  tshirt: "Get a T-Shirt"
+  tshirt_url: "https://scalamatsuri.myshopify.com/collections/all"
   cfp: "Call for proposals"
   ticket: "Ticket"
 ja:
   sponsorship: "スポンサー募集"
+  tshirt: "Tシャツ購入"
+  tshirt_url: "https://scalamatsuri.official.ec/"
   cfp: "セッションに応募する"
   ticket: "チケット購入"
 </i18n>
 <template>
   <div class="banner">
     <div class="banner_list">
+      <!--
       <nuxt-link :to="localePath('sponsorship')" class="banner_item banner_item-sponsor">
         <span>{{ $t('sponsorship') }} </span>
       </nuxt-link>
-      <!-- <nuxt-link :to="localePath('cfp')" class="banner_item banner_item-staff">
+      -->
+      <a :href="$t('tshirt_url')" class="banner_item banner_item-tshirt">
+        <span>{{ $t('tshirt') }} </span>
+      </a>
+      <!--
+      <nuxt-link :to="localePath('cfp')" class="banner_item banner_item-staff">
         <span>{{ $t('cfp') }}</span>
-      </nuxt-link> -->
+      </nuxt-link>
+      -->
       <a href="https://scalaconfjp.doorkeeper.jp/events/103550" target="_blank" rel="noopener" class="banner_item banner_item-staff">
         <span>{{ $t('ticket') }}</span>
       </a>

--- a/nuxt_src/pages/extra-staff/index.vue
+++ b/nuxt_src/pages/extra-staff/index.vue
@@ -7,15 +7,21 @@
         </h1>
       </div>
     </div>
+
     <div class="lead">
       <img v-lazy="require('~/assets/img/extra-staff/img-main.jpg')" alt="" class="lead_img is_sp">
       <div class="lead_inner">
         <h2 class="lead_text">
           イベントを一緒に盛り上げる<br>仲間を募集しています
         </h2>
+        <!--
         <div class="section_btnArea lead_btnArea">
           <a href="https://forms.gle/SkbscteHs4nzGPZB8" target="_blank" rel="noopener" class="section_btn section_btn-l">スタッフに応募する</a>
         </div>
+        -->
+        <p class="extrastaff_note">
+          2020/10/1 ScalaMatsuri 2020 <strong>直前期スタッフ募集は締め切りました。</strong><br> たくさんのご応募、誠にありがとうございました。
+        </p>
       </div>
     </div>
     <p class="catch">

--- a/nuxt_src/pages/sponsorship/index.vue
+++ b/nuxt_src/pages/sponsorship/index.vue
@@ -7,11 +7,7 @@
         </h1>
       </div>
     </div>
-    <!--
-    <div class="notification">
-      2020/2/12 ご好評につき常設ブースは<strong>完売いたしました。</strong>
-    </div>
-    -->
+    <div class="notification" />
 
     <!-- sponsorship ここから -->
     <div class="sponsorship">
@@ -23,16 +19,16 @@
       </p>
       <div class="sponsorship_btnArea">
         <a href="/pdf/sponsorship.pdf" class="sponsorship_btn sponsorship_btn-pdf">スポンサーシップのご案内</a>
+        <!--
         <a href="https://forms.gle/jz29vPswF52yUnZB8" class="sponsorship_btn sponsorship_btn-form">お申込みフォーム</a>
+        -->
       </div>
-      <!--
       <p class="sponsorship_note">
-        年末年始は、2019年12月28日(土)から2020年1月5日(日)までスポンサー窓口はお休みです。<br>2019年12月26日(木)23:59JSTまでにスポンサーのお申し込みいただいた場合は、請求書を年内にご送付いたします。
+        2020/10/1 ScalaMatsuri 2020 <strong>スポンサー募集は締め切りました。</strong><br>たくさんのご応募、誠にありがとうございました。
       </p>
-      -->
     </div>
     <!-- sponsorship ここまで -->
-    <!-- recruit ここまで -->
+    <!-- recruit ここから -->
     <section class="section recruit">
       <h2 class="section_title">
         <span class="section_title_inner">特別企画 - 私、ScalaMatsuriで転職しました -</span>
@@ -217,13 +213,13 @@
       </p>
       <div class="sponsorship_btnArea">
         <a href="/pdf/sponsorship.pdf" class="sponsorship_btn sponsorship_btn-pdf">スポンサーシップのご案内</a>
+        <!--
         <a href="https://forms.gle/jz29vPswF52yUnZB8" class="sponsorship_btn sponsorship_btn-form">お申込みフォーム</a>
+        -->
       </div>
-      <!--
       <p class="sponsorship_note">
-        年末年始は、2019年12月28日(土)から2020年1月5日(日)までスポンサー窓口はお休みです。<br>2019年12月26日(木)23:59JSTまでにスポンサーのお申し込みいただいた場合は、請求書を年内にご送付いたします。
+        2020/10/1 ScalaMatsuri 2020 <strong>スポンサー募集は締め切りました。</strong><br>たくさんのご応募、誠にありがとうございました。
       </p>
-      -->
     </div>
     <!-- sponsorship ここまで -->
     <section class="inquiry">


### PR DESCRIPTION
スポンサー募集と直前期スタッフ募集が停止したことを受けて、Webサイトに変更を反映しました。

## TOP
- スポンサー募集ページと、直前期スタッフ募集ページの導線を消しました。
- トップのボタンは、こんな感じでTシャツショップへのボタンにしてみました。

![89da78a34d4b21db77467e0969e0a3d1](https://user-images.githubusercontent.com/1506707/94802218-36d10800-0422-11eb-93f3-5eb7dddad746.png)
![d12a1eac5eddbdcd8cf9508fb0373a35](https://user-images.githubusercontent.com/1506707/94802224-38023500-0422-11eb-9c03-16f576a88e1d.png)

## スポンサー募集ページ
- 導線は消したものの、404にはしていません
- フォームへのリンクを消しました
- 申し込み終了の案内を書きました
![4f98e44fef08ee5074a91ae4bd043c3b](https://user-images.githubusercontent.com/1506707/94802225-389acb80-0422-11eb-8a2e-2f3fc2f0f301.png)

## 直前期スタッフ募集ページ
- 導線は消したものの、404にはしていません
- フォームへのリンクを消しました
- 申し込み終了の案内を書きまし
![7a3b31eff410912e5e70f912819aea43](https://user-images.githubusercontent.com/1506707/94802226-39336200-0422-11eb-9241-a4000f69d691.png)
