### PR TITLE
Remove a dead link from the footer area

### DIFF
--- a/nuxt_src/components/parts/TheFooter.vue
+++ b/nuxt_src/components/parts/TheFooter.vue
@@ -61,9 +61,11 @@ ja:
           <!--          <dd class="footerNav_item">-->
           <!--            <a :href="localePath('extra-staff')">{{ $t('extra_staff') }}</a>-->
           <!--          </dd>-->
+          <!--
           <dd class="footerNav_item">
             <a :href="localePath('travel')">{{ $t('travel') }}</a>
           </dd>
+          -->
           <dd class="footerNav_item">
             <a href="https://docs.google.com/forms/d/e/1FAIpQLSftjA6961ZzzJjqq1CrWtAN9wwrqXRUGFqZI5G8x2BjmZHeWw/viewform" target="_blank" rel="noopener">{{ $t('help') }}</a>
           </dd>


### PR DESCRIPTION
https://github.com/scalamatsuri/2020.scalamatsuri.org/pull/414 で `/travel` がアクセス不能になりましたが、フッターにまだリンクが残っているようです。コメントアウトとしましたが、削除でもよいかと思います。